### PR TITLE
fix: force save project when exporting video with --no-save flag

### DIFF
--- a/lecture-video-composer/src/core/lecture_composer.py
+++ b/lecture-video-composer/src/core/lecture_composer.py
@@ -355,6 +355,11 @@ def main():
         
         # 导出视频（如果需要）
         if args.export_video:
+            # 如果使用了 --no-save，强制保存文件以便导出视频
+            if args.no_save:
+                logger.warning("⚠️  --no-save conflicts with --export-video. Files will be saved for video export.")
+                composer.save_project()
+            
             logger.info("\n" + "=" * 60)
             logger.info("Exporting video...")
             logger.info("=" * 60)


### PR DESCRIPTION
Add validation to handle conflicting --no-save and --export-video flags. When both flags are provided, project files are now automatically saved with a warning message, as video export requires saved project files to function.