### PR TITLE
Fix preferences initialization and add session files to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,6 @@ lecture-video-composer/src/services/image/__pycache__/image_service.cpython-313.
 lecture-video-composer/src/services/metadata/__pycache__/metadata_service.cpython-313.pyc
 lecture-video-composer/src/services/subtitle/__pycache__/subtitle_service.cpython-313.pyc
 lecture-video-composer/src/services/video/__pycache__/video_exporter.cpython-313.pyc
+
+# 忽略临时会话文件
+lecture-video-composer/data/temp/sessions/*.json


### PR DESCRIPTION
- Add null checks for preferences to prevent errors during initialization
- Move preferences subscription after restorePreferences() to avoid early errors
- Add default values for player options when preferences are undefined
- Ignore temporary session JSON files in data/temp/sessions/
- Add safety check in applyPreferences() to handle null preferences