### PR TITLE
Fix player image rendering and button issues caused by placeholder ov…

### DIFF
--- a/lecture-video-composer/docs/bugfix/播放器图片渲染和按钮问题修复.md
+++ b/lecture-video-composer/docs/bugfix/播放器图片渲染和按钮问题修复.md
@@ -9,10 +9,11 @@
    - 播放按钮无法点击
    - 但键盘空格键可以开始播放音频文件
 
-2. **图片没有正确渲染**
+2. **图片没有正确渲染 - 蓝色占位符遮挡**
    - 控制台显示图片文件正常加载
    - 播放过程中声音正常播放
-   - 但没有视频图像，只显示一个蓝色图形
+   - 但没有视频图像，只显示一个蓝色圆形图案
+   - 蓝色图案遮挡整个播放器展示框
 
 ## 问题分析
 
@@ -26,20 +27,93 @@
 - `app.html`: 播放按钮初始状态为 `disabled`
 - `app.js`: `initPlayer()` 中的 `loaded` 事件处理器应该启用按钮
 
-### 2. 图片渲染问题
+### 2. 图片渲染问题 - 占位符遮挡
 
-**原因**：
+**主要原因**：
+- `photo-placeholder` 占位符元素覆盖在 canvas 上方
+- CSS 中占位符默认 `display: flex`（可见状态）
+- 即使 canvas 正确绘制了图片，也被蓝紫色渐变占位符遮挡
+- JavaScript 设置 `display: none` 可能因 CSS 优先级或时序问题未生效
+
+**次要原因**：
 - `_drawPhoto()` 方法在绘制图片前没有清空画布背景
-- `drawImageCentered()` 工具函数中调用了 `ctx.clearRect()`，但这会清除背景而不会填充新的背景色
-- Canvas 背景色是深蓝色 (`#1a1a2e`)，当图片没有正确绘制时就显示这个颜色
+- Canvas 背景色问题
 
 **定位**：
+- `player.css`: `.photo-placeholder` 样式（覆盖层）
+- `app.html`: 占位符元素初始状态
+- `app.js`: `loaded` 事件中隐藏占位符的逻辑
 - `player.js`: `_drawPhoto()` 方法
-- `utils.js`: `drawImageCentered()` 函数
 
 ## 修复方案
 
-### 修复 1: player.js - 图片渲染问题
+### 修复 1: player.css - 占位符覆盖问题（核心修复）
+
+**文件**: `lecture-video-composer/src/web/static/css/player.css`
+
+**修改**: `.photo-placeholder` 样式
+
+```css
+.photo-placeholder {
+    position: absolute;
+    inset: 0;
+    display: none;  /* 默认隐藏 */
+    flex-direction: column;
+    align-items: center;
+    justify-content: center;
+    background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
+    color: white;
+    z-index: 10;  /* 确保在 canvas 上方 */
+}
+
+.photo-placeholder.show {
+    display: flex;  /* 通过类名控制显示 */
+}
+```
+
+**说明**：
+- 将占位符默认改为 `display: none`（隐藏）
+- 添加 `.show` 类来控制显示，使用 `display: flex`
+- 通过类名控制比直接修改 `style.display` 更可靠
+- 添加 `z-index: 10` 确保层级关系清晰
+
+### 修复 2: app.html - 占位符初始状态
+
+**文件**: `lecture-video-composer/src/web/static/app.html`
+
+**修改**: 添加 `show` 类
+
+```html
+<div class="photo-placeholder show" id="photo-placeholder">
+    <span class="placeholder-icon">🖼️</span>
+    <p>等待加载照片...</p>
+</div>
+```
+
+**说明**：
+- 初始添加 `show` 类，在未加载项目时显示占位符
+- 项目加载后通过 JavaScript 移除 `show` 类隐藏占位符
+
+### 修复 3: app.js - 隐藏占位符逻辑
+
+**文件**: `lecture-video-composer/src/web/static/js/app.js`
+
+**修改**: `initPlayer()` 方法中的 `loaded` 事件处理
+
+```javascript
+// 隐藏占位符，显示播放器
+const photoPlaceholder = document.getElementById('photo-placeholder');
+if (photoPlaceholder) {
+    photoPlaceholder.classList.remove('show');  // 移除 show 类
+}
+```
+
+**说明**：
+- 从直接设置 `style.display` 改为移除 `show` 类
+- 更符合 CSS 类名控制的最佳实践
+- 避免内联样式与 CSS 样式的优先级冲突
+
+### 修复 4: player.js - 图片渲染背景
 
 **文件**: `lecture-video-composer/src/web/static/js/player.js`
 
@@ -128,6 +202,7 @@ if (playBtn) {
    - 打开项目进入播放器视图
 
 4. **验证修复**
+   - ✅ 确认蓝色占位符已隐藏
    - ✅ 确认第一张照片正确显示（不是蓝色背景）
    - ✅ 点击播放按钮可以正常播放
    - ✅ 播放过程中照片按时间轴切换
@@ -136,47 +211,69 @@ if (playBtn) {
 
 ### 预期结果
 
-- 项目加载后，canvas 上立即显示第一张照片
-- 播放按钮可点击，点击后开始播放
-- 播放过程中，照片根据时间轴正确切换
-- 照片以黑色背景居中显示，保持原始宽高比
+- **打开播放器视图时**：显示蓝色占位符提示"等待加载照片..."
+- **项目加载后**：
+  - 蓝色占位符立即消失
+  - Canvas 上立即显示第一张照片
+  - 播放按钮变为可点击状态
+- **播放过程中**：
+  - 照片根据时间轴正确切换
+  - 照片以黑色背景居中显示，保持原始宽高比
+  - 音频和图片同步播放
 
 ## 相关代码位置
 
 ### 主要修改文件
 
-1. **player.js** - 播放器核心逻辑
-   - `_drawPhoto()` 方法：修复图片渲染
+1. **player.css** - 播放器样式（核心修复）
+   - `.photo-placeholder` 样式：默认隐藏，通过类名控制显示
+   - 添加 `.photo-placeholder.show` 规则
    
-2. **app.js** - 应用主控制器
+2. **app.html** - HTML 结构
+   - `photo-placeholder` 元素：添加 `show` 类
+
+3. **app.js** - 应用主控制器
+   - `initPlayer()` 中的 `loaded` 事件：移除 `show` 类隐藏占位符
    - `initPlaybackControls()` 方法：修复按钮事件处理
+   
+4. **player.js** - 播放器核心逻辑
+   - `_drawPhoto()` 方法：修复图片渲染背景
 
 ### 相关辅助文件
 
 - `utils.js`: `drawImageCentered()` 工具函数（未修改）
-- `app.html`: 播放器 HTML 结构（未修改）
-- `player.css`: 播放器样式（未修改）
 
 ## 注意事项
 
-1. **Canvas 背景色**
+1. **占位符层级控制**
+   - 使用 CSS 类名控制显示/隐藏比直接修改 `style.display` 更可靠
+   - 避免内联样式与 CSS 规则的优先级冲突
+   - `z-index: 10` 确保占位符在 canvas 上方
+
+2. **Canvas 背景色**
    - 使用黑色 (#000) 而非深蓝色作为播放器背景
    - 更符合照片/视频播放器的视觉习惯
 
-2. **图片加载**
+3. **图片加载时序**
    - 图片通过 `Image` 对象异步加载
    - 加载完成后才会触发 `loaded` 事件
-   - 确保所有照片加载完成后才显示第一张
+   - 确保所有照片加载完成后才隐藏占位符
+   - 占位符隐藏与第一张照片绘制同步进行
 
-3. **按钮状态管理**
+4. **按钮状态管理**
    - 按钮初始为 `disabled` 状态
    - 项目加载完成后通过 `loaded` 事件启用
    - 播放/暂停状态切换时更新按钮图标
 
-4. **错误处理**
+5. **错误处理**
    - `play()` 方法返回 Promise
    - 需要使用 `catch()` 处理可能的播放失败
    - 常见失败原因：浏览器自动播放策略限制
+
+6. **CSS 最佳实践**
+   - 优先使用类名控制元素状态
+   - 避免在 JavaScript 中直接修改 style 属性
+   - 使用语义化的类名（如 `show`/`hide`）
 
 ## 修复时间
 

--- a/lecture-video-composer/src/web/static/app.html
+++ b/lecture-video-composer/src/web/static/app.html
@@ -155,7 +155,7 @@
                         <!-- 照片显示区域 -->
                         <div class="photo-display">
                             <canvas id="photo-canvas" width="1280" height="720"></canvas>
-                            <div class="photo-placeholder" id="photo-placeholder">
+                            <div class="photo-placeholder show" id="photo-placeholder">
                                 <span class="placeholder-icon">🖼️</span>
                                 <p>等待加载照片...</p>
                             </div>

--- a/lecture-video-composer/src/web/static/css/player.css
+++ b/lecture-video-composer/src/web/static/css/player.css
@@ -33,12 +33,17 @@
 .photo-placeholder {
     position: absolute;
     inset: 0;
-    display: flex;
+    display: none;
     flex-direction: column;
     align-items: center;
     justify-content: center;
     background: linear-gradient(135deg, #667eea 0%, #764ba2 100%);
     color: white;
+    z-index: 10;
+}
+
+.photo-placeholder.show {
+    display: flex;
 }
 
 .placeholder-icon {

--- a/lecture-video-composer/src/web/static/js/app.js
+++ b/lecture-video-composer/src/web/static/js/app.js
@@ -193,7 +193,7 @@ class App {
             // 隐藏占位符，显示播放器
             const photoPlaceholder = document.getElementById('photo-placeholder');
             if (photoPlaceholder) {
-                photoPlaceholder.style.display = 'none';
+                photoPlaceholder.classList.remove('show');
             }
             
             // 隐藏空状态提示


### PR DESCRIPTION
…erlay

- Change photo-placeholder to be hidden by default (display: none)
- Add .show class to control placeholder visibility via CSS
- Update app.html to use .show class for initial placeholder state
- Modify app.js to hide placeholder by removing .show class instead of inline style
- Fix _drawPhoto() to fill canvas with black background before drawing images
- Enable play button after project loads in initPlayer() event handler
- Update bugfix documentation with detailed root cause analysis

The main issue was the blue gradient placeholder overlaying the canvas even after images were loaded. Using CSS class-based visibility control instead of inline styles resolves the z-index conflict and ensures proper rendering.