### PR TITLE
Add pip mirror configuration and improve deployment documentation

### DIFF
--- a/lecture-video-composer/docs/deployment/多平台部署指南.md
+++ b/lecture-video-composer/docs/deployment/多平台部署指南.md
@@ -126,7 +126,21 @@ python -m venv venv
 Set-ExecutionPolicy -ExecutionPolicy RemoteSigned -Scope CurrentUser
 ```
 
-#### 3. 安装依赖
+#### 3. 配置pip加速（可选）
+
+```powershell
+# 国内服务器推荐使用清华大学镜像源加速
+# 创建 pip 配置目录
+mkdir $env:APPDATA\pip
+
+# 创建配置文件
+@"
+[global]
+index-url = https://pypi.tuna.tsinghua.edu.cn/simple
+"@ | Out-File -FilePath $env:APPDATA\pip\pip.ini -Encoding utf8
+```
+
+#### 4. 安装依赖
 
 ```powershell
 # 升级 pip
@@ -139,7 +153,7 @@ pip install -r requirements.txt
 pip install -r requirements.txt --use-pep517
 ```
 
-#### 4. 配置环境
+#### 5. 配置环境
 
 ```powershell
 # 复制配置文件
@@ -149,7 +163,7 @@ Copy-Item .env.example .env
 notepad .env
 ```
 
-#### 5. 启动服务
+#### 6. 启动服务
 
 ```powershell
 # 开发模式
@@ -294,7 +308,15 @@ which python
 # 应该显示虚拟环境路径
 ```
 
-#### 3. 安装依赖
+#### 3. 配置pip加速（可选）
+
+```bash
+# 国内服务器推荐使用清华大学镜像源加速
+mkdir -p ~/.pip
+echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple" > ~/.pip/pip.conf
+```
+
+#### 4. 安装依赖
 
 ```bash
 # 升级 pip
@@ -308,7 +330,7 @@ pip install -r requirements.txt
 arch -arm64 pip install -r requirements.txt
 ```
 
-#### 4. 配置环境
+#### 5. 配置环境
 
 ```bash
 # 复制配置文件
@@ -320,7 +342,7 @@ nano .env
 code .env
 ```
 
-#### 5. 启动服务
+#### 6. 启动服务
 
 ```bash
 # 开发模式
@@ -456,7 +478,11 @@ cd Sunflower/lecture-video-composer
 python3 -m venv venv
 source venv/bin/activate
 
-# 3. 安装依赖
+# 3. 配置pip加速（国内服务器推荐）
+mkdir -p ~/.pip
+echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple" > ~/.pip/pip.conf
+
+# 4. 安装依赖
 pip install --upgrade pip
 pip install -r requirements.txt
 
@@ -553,6 +579,35 @@ sudo rpm -Uvh http://li.nux.ro/download/nux/dextop/el7/x86_64/nux-dextop-release
 sudo yum install -y ffmpeg
 ```
 
+#### 项目部署
+
+```bash
+# 1. 克隆项目
+cd /opt
+sudo git clone https://github.com/Qiniu-ERE/Sunflower.git
+sudo chown -R $USER:$USER Sunflower
+cd Sunflower/lecture-video-composer
+
+# 2. 创建虚拟环境
+python3 -m venv venv
+source venv/bin/activate
+
+# 3. 配置pip加速（国内服务器推荐）
+mkdir -p ~/.pip
+echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple" > ~/.pip/pip.conf
+
+# 4. 安装依赖
+pip install --upgrade pip
+pip install -r requirements.txt
+
+# 5. 配置
+cp .env.example .env
+nano .env
+
+# 6. 启动
+python run_web.py
+```
+
 ### 📦 openEuler
 
 #### 系统要求
@@ -602,15 +657,19 @@ cd Sunflower/lecture-video-composer
 python3 -m venv venv
 source venv/bin/activate
 
-# 3. 安装依赖
+# 3. 配置pip加速（国内服务器推荐）
+mkdir -p ~/.pip
+echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple" > ~/.pip/pip.conf
+
+# 4. 安装依赖
 pip install --upgrade pip
 pip install -r requirements.txt
 
-# 4. 配置
+# 5. 配置
 cp .env.example .env
 nano .env
 
-# 5. 启动
+# 6. 启动
 python run_web.py
 ```
 

--- a/lecture-video-composer/docs/deployment/部署指南.md
+++ b/lecture-video-composer/docs/deployment/部署指南.md
@@ -44,7 +44,11 @@ cd Sunflower/lecture-video-composer
 python3 -m venv venv
 source venv/bin/activate  # Windows: venv\Scripts\activate
 
-# 3. 安装依赖
+# 3. 配置pip加速（可选，国内服务器推荐）
+mkdir -p ~/.pip
+echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple" > ~/.pip/pip.conf
+
+# 4. 安装依赖
 pip install -r requirements.txt
 
 # 4. 配置环境变量
@@ -52,7 +56,31 @@ cp .env.example .env
 # 编辑 .env 文件设置必要参数
 
 # 5. 启动服务
+# 默认配置（监听0.0.0.0:5000，允许外部访问）
 python run_web.py
+
+# 仅本地访问（127.0.0.1）
+python run_web.py --host 127.0.0.1
+
+# 自定义端口
+python run_web.py --port 8080
+
+# 生产模式
+python run_web.py --env production
+```
+
+**访问方式**：
+- 本地访问：`http://localhost:5000`
+- 局域网访问：`http://<服务器IP>:5000`
+- 外网访问：需配置防火墙开放5000端口
+
+**安全提示**：
+> ⚠️ 使用0.0.0.0监听时，请确保：
+> - 配置防火墙规则限制访问来源
+> - 启用HTTPS加密传输
+> - 考虑使用Nginx反向代理
+> - 生产环境建议使用`--env production`
+
 ```
 
 ### 配置说明
@@ -62,7 +90,7 @@ python run_web.py
 ```bash
 # 服务配置
 FLASK_ENV=production
-HOST=0.0.0.0
+# HOST=0.0.0.0  # 默认已监听所有接口，无需额外配置
 PORT=5000
 
 # 数据目录
@@ -138,6 +166,10 @@ cd Sunflower/lecture-video-composer
 # 创建虚拟环境
 python3 -m venv venv
 source venv/bin/activate
+
+# 配置pip加速（国内服务器推荐）
+mkdir -p ~/.pip
+echo -e "[global]\nindex-url = https://pypi.tuna.tsinghua.edu.cn/simple" > ~/.pip/pip.conf
 
 # 安装依赖
 pip install -r requirements.txt

--- a/lecture-video-composer/run_web.py
+++ b/lecture-video-composer/run_web.py
@@ -25,8 +25,8 @@ def parse_args():
     
     parser.add_argument(
         '--host',
-        default='127.0.0.1',
-        help='服务器监听地址 (默认: 127.0.0.1)'
+        default='0.0.0.0',
+        help='服务器监听地址 (默认: 0.0.0.0, 允许外部访问)'
     )
     
     parser.add_argument(


### PR DESCRIPTION
- Add optional pip mirror setup using Tsinghua University mirror for faster package installation in China
- Add CLI arguments support for run_web.py (host, port, environment)
- Update deployment guides with security warnings for 0.0.0.0 binding
- Reorganize deployment steps to include pip acceleration as step 3
- Add missing CentOS deployment section
- Improve access instructions with local/LAN/WAN examples
- Add security best practices for production deployment