### PR TITLE
Add demo video to README documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,9 +49,16 @@
 <!-- 演示视频 -->
 ### 📹 演示视频
 
-> 🚧待添加：系统操作演示视频
+<video width="100%" controls>
+  <source src="http://rzkkr9sg3.hd-bkt.clouddn.com/test_tools/039f854e886ae45cc4947318ba4b9dfa.mov" type="video/mp4">
+  您的浏览器不支持 video 标签。请<a href="http://rzkkr9sg3.hd-bkt.clouddn.com/test_tools/039f854e886ae45cc4947318ba4b9dfa.mov">点击这里下载视频</a>。
+</video>
 
-![Demo Video Placeholder](./lecture-video-composer/docs/assets/demo-video-placeholder.png)
+**视频内容：**
+- 文件上传与项目创建流程
+- 实时播放器操作演示
+- 时间轴精确控制
+- 视频导出功能展示
 
 <!-- 界面截图 -->
 ### 🖼️ 界面预览

--- a/lecture-video-composer/README.md
+++ b/lecture-video-composer/README.md
@@ -19,13 +19,13 @@
 ---
 
 ## 🎬 效果展示
-
 <!-- 演示视频 -->
 ### 📹 演示视频
 
-> 🚧待添加：系统操作演示视频
-
-![Demo Video Placeholder](./docs/assets/demo-video-placeholder.png)
+<video width="100%" controls>
+  <source src="http://rzkkr9sg3.hd-bkt.clouddn.com/test_tools/039f854e886ae45cc4947318ba4b9dfa.mov" type="video/mp4">
+  您的浏览器不支持 video 标签。请<a href="http://rzkkr9sg3.hd-bkt.clouddn.com/test_tools/039f854e886ae45cc4947318ba4b9dfa.mov">点击这里下载视频</a>。
+</video>
 
 <!-- 界面截图 -->
 ### 🖼️ 界面预览


### PR DESCRIPTION
Replace placeholder image with embedded video demonstration showing file upload, player controls, timeline navigation, and export functionality. Video hosted on CDN with fallback download link for unsupported browsers.